### PR TITLE
domain_prefix fix and Decimal Type Addition

### DIFF
--- a/lib/SimpleDB/Class.pm
+++ b/lib/SimpleDB/Class.pm
@@ -280,7 +280,6 @@ Returns a boolean indicating whether the user has specified a domain_prefix.
 has domain_prefix => (
     is          => 'ro',
     predicate   => 'has_domain_prefix',
-    default     => undef,
 );
 
 #--------------------------------------------------------

--- a/lib/SimpleDB/Class/Domain.pm
+++ b/lib/SimpleDB/Class/Domain.pm
@@ -76,6 +76,22 @@ has name => (
 
 #--------------------------------------------------------
 
+=head2 name_fq ( )
+
+Returns the fully qualified name determined automatically by the item_class passed into the constructor.
+
+=cut
+
+has name_fq => (
+    is          => 'ro',
+    default     => undef,
+    lazy        => 1,
+    writer => '_set_name_fq',
+);
+
+#--------------------------------------------------------
+#
+
 =head2 simpledb ( )
 
 Returns the L<SimpleDB::Class> object set in the constructor.
@@ -85,6 +101,15 @@ Returns the L<SimpleDB::Class> object set in the constructor.
 has simpledb => (
     is          => 'ro',
     required    => 1,
+    trigger     => sub {
+        my ($self, $new, $old) = @_;
+        if ($new->has_domain_prefix) {
+            $self->_set_name_fq($new->domain_prefix . $self->name);
+        }
+        else {
+            $self->_set_name_fq($self->name);
+        } 
+    },
 );
 
 #--------------------------------------------------------

--- a/lib/SimpleDB/Class/Domain.pm
+++ b/lib/SimpleDB/Class/Domain.pm
@@ -99,7 +99,7 @@ sub create {
     my ($self) = @_;
     my $db = $self->simpledb;
     $db->http->send_request('CreateDomain', {
-        DomainName => $db->add_domain_prefix($self->name),
+        DomainName => $db->add_domain_prefix($self->name)
     });
 }
 

--- a/lib/SimpleDB/Class/Item.pm
+++ b/lib/SimpleDB/Class/Item.pm
@@ -584,6 +584,9 @@ sub stringify_value {
     if ($isa =~ /Int$/) {
         return to_SdbIntAsStr($value); 
     }
+    elsif ($isa =~ /Decimal$/) {
+        return to_SdbDecimalAsStr($value);
+    }
     else {
         return to_SdbStr($value);
     }
@@ -625,6 +628,12 @@ sub stringify_values {
     }
     elsif ($isa eq 'SimpleDB::Class::Types::SdbInt') {
         return to_SdbIntAsStr($value); 
+    }
+    if ($isa eq 'SimpleDB::Class::Types::SdbArrayRefOfDecimal') {
+        return to_SdbArrayRefOfDecimalAsStr($value);
+    }
+    elsif ($isa eq 'SimpleDB::Class::Types::SdbDecimal') {
+        return to_SdbDecimalAsStr($value);
     }
     elsif ($isa =~ m/ArrayRefOf|HashRef|MediumStr/) {
         return to_SdbArrayRefOfStr($value);

--- a/lib/SimpleDB/Class/Item.pm
+++ b/lib/SimpleDB/Class/Item.pm
@@ -373,6 +373,13 @@ Returns the simpledb passed into the constructor.
 has simpledb => (
     is          => 'ro',
     required    => 1,
+    trigger => sub {
+        my ($self, $new, $old)  = @_;
+
+        if ($new->has_domain_prefix) {
+            $self->_set_domain_name_fq($new->domain_prefix . $self->domain_name);
+        }
+    },
 );
 
 #--------------------------------------------------------
@@ -388,6 +395,22 @@ has id => (
     isa         => SdbStr,
     builder     => 'generate_uuid',
     lazy        => 1,
+);
+
+#--------------------------------------------------------
+
+
+=head2 domain_name_fq ( )
+
+Fully qualified domain name
+
+=cut
+
+has domain_name_fq => (
+    is          => 'ro',
+    default     => undef,
+    lazy        => 1,
+    writer      => '_set_domain_name_fq',
 );
 
 #--------------------------------------------------------

--- a/lib/SimpleDB/Class/Types.pm
+++ b/lib/SimpleDB/Class/Types.pm
@@ -177,10 +177,10 @@ coerce SdbDecimalAsStr,
     from SdbDecimal, via { 
         my @parts = split(/\./, $_);
         if ($parts[1]) {
-            sprintf("dec%015d.%s", ($parts[0] + 1000000000), $parts[1] );
+            return sprintf("dec%015d.%s", ($parts[0] + 1000000000), $parts[1] );
         }
         else {
-            sprintf("dec%015d", ($parts[0] + 1000000000));
+            return sprintf("dec%015d", ($parts[0] + 1000000000));
         }
     };
 

--- a/lib/SimpleDB/Class/Types.pm
+++ b/lib/SimpleDB/Class/Types.pm
@@ -11,11 +11,12 @@ The allowable value types for L<SimpleDB::Class::Item> attributes.
 =head1 SYNOPSIS
 
  Type                   | Default        | Range
- -----------------------+----------------+-----------------------------------------------
+ -----------------------+----------------+----------------------------------------------------
  Str                    | ''             | 0 to 1024 characters 
  MediumStr              | ''             | 0 to 259,080 chracters
  ArrayRefOfStr          | []             | 254 Str elements
  Int                    | 0              | -999,999,999 to 99,999,999,999,999 (no commas)
+ Decimal                | 0              | -999,999,999.0 to 99,999,999,999,999.9999999999 
  ArrayRefOfInt          | []             | 254 Int elements
  DateTime               | now()          | Any DateTime object
  ArrayRefOfDateTime     | []             | 254 DateTime elements
@@ -41,9 +42,20 @@ A string of up to 259,080 characters. Defaults to C<''>. Use this B<only> if you
 
 An integer between -999,999,999 and 99,999,999,999,999 (without the commas). Defaults to C<0>. Is completely searchable and sortable.
 
+
 =head2 ArrayRefOfInt
 
 An array reference of integers which can have up to 254 elements. Each integer follows the rules of C<Int>. If you need a multi-value integer type, this is the way to go. See B<Attribute Limits> for special considerations about this type.
+
+=head2 Decimal
+
+An integer between -999,999,999.0 and 99,999,999,999,999.9999999999 (without the commas). Defaults to C<0>. Is completely searchable and sortable. Decimal can actually span past the decimal point until 1021 total characters have been used. Anything more than 8 places past the decimal point however (usually used for geocoded lat/long) is not recommended.
+
+
+=head2 ArrayRefOfDecimal
+
+An array reference of decimals which can have up to 254 elements. Each integer follows the rules of C<Decimal>. If you need a multi-value decimal type, this is the way to go. See B<Attribute Limits> for special considerations about this type.
+
 
 =head2 DateTime
 
@@ -63,7 +75,7 @@ A hash reference. For storage this is serialized into JSON and stored as a C<Med
 
 =head1 Attribute Limits
 
-SimpleDB Items are limited to 256 attributes each. This means that they can have no more than any combination of names, values, or multi values. So you can have 256 name/value pairs, or you could have one multi-valued attribute with 256 elements, or anything in between. For that reason, be careful when adding ArrayRefOfDateTime, ArrayRefOfInt, ArrayRefOfStr, MediumStr, and HashRef elements to your items. 
+SimpleDB Items are limited to 256 attributes each. This means that they can have no more than any combination of names, values, or multi values. So you can have 256 name/value pairs, or you could have one multi-valued attribute with 256 elements, or anything in between. For that reason, be careful when adding ArrayRefOfDateTime, ArrayRefOfInt, ArrayRefOfDecimal, ArrayRefOfStr, MediumStr, and HashRef elements to your items. 
 
 =cut
 
@@ -246,7 +258,8 @@ coerce SdbDecimal,
     from SdbStr, via {
         if ($_ =~ m/^dec((\d{15})(\.(\d+))?)$/) {
             if ($3) {
-                # Rounding errors correction
+                # Rounding error correction
+                # http://answers.oreilly.com/topic/415-how-to-round-floating-point-numbers-in-perl/
                 my $precision = length($4); 
                 return sprintf("%.$precision" . 'f', $1 - 1000000000);
             }

--- a/lib/SimpleDB/Class/Types.pm
+++ b/lib/SimpleDB/Class/Types.pm
@@ -175,12 +175,13 @@ coerce SdbIntAsStr,
 
 coerce SdbDecimalAsStr,
     from SdbDecimal, via { 
-        my @parts = split(/\./, $_);
+        my $num = $_ + 1000000000;
+        my @parts = split(/\./, $num);
         if ($parts[1]) {
-            return sprintf("dec%015d.%s", ($parts[0] + 1000000000), $parts[1] );
+            return sprintf("dec%015d.%s", @parts );
         }
         else {
-            return sprintf("dec%015d", ($parts[0] + 1000000000));
+            return sprintf("dec%015d", $parts[0] );
         }
     };
 
@@ -243,10 +244,15 @@ coerce SdbInt,
 
 coerce SdbDecimal,
     from SdbStr, via {
-        if ($_ =~ m/^dec(\d{15})(\.(\d+))?$/) {
-            my $num = $1 - 1000000000;
-            $num .= '.' . $3 if $3;
-            return $num
+        if ($_ =~ m/^dec((\d{15})(\.(\d+))?)$/) {
+            if ($3) {
+                # Rounding errors correction
+                my $precision = length($4); 
+                return sprintf("%.$precision" . 'f', $1 - 1000000000);
+            }
+            else {
+                return $1 - 1000000000;
+            }
         }
         else {
             return 0;

--- a/t/04.Types.t
+++ b/t/04.Types.t
@@ -37,15 +37,15 @@ is(to_SdbDecimal([5]), 5, 'coerce array of decimal to decimal');
 
 
 # decimal 
-is(to_SdbDecimalAsStr(-4.25), 'dec000000999999996.25', 'coersion from decimal to string');
+is(to_SdbDecimalAsStr(-4.25), 'dec000000999999995.75', 'coersion from decimal to string');
 ok(is_SdbDecimal(-4.25), 'can identify decimal');
-is(to_SdbDecimal('dec000000999999996.25'), -4.25, 'coersion from string to decimal');
+is(to_SdbDecimal('dec000000999999995.75'), -4.25, 'coersion from string to decimal');
 my @aofi = (1.25,-2.36,3.47);
-my @aofis = ('dec000001000000001.25','dec000000999999998.36','dec000001000000003.47');
+my @aofis = ('dec000001000000001.25','dec000000999999997.64','dec000001000000003.47');
 is(to_SdbArrayRefOfDecimalAsStr(\@aofi)->[1], $aofis[1], 'array of decimal converts to array of str');
 is(to_SdbArrayRefOfDecimal(\@aofis)->[1], $aofi[1], 'array of str converts to array of decimal');
 ok(ref to_SdbArrayRefOfDecimal(1) eq 'ARRAY', 'coerce decimal to array');
-is(to_SdbDecimal(['dec000000999999996.25']), -4.25, 'coerce decimal of str to decimal');
+is(to_SdbDecimal(['dec000000999999995.75']), -4.25, 'coerce decimal of str to decimal');
 is(to_SdbDecimal([5.25]), 5.25, 'coerce array of decimal to decimal');
 
 

--- a/t/04.Types.t
+++ b/t/04.Types.t
@@ -1,4 +1,4 @@
-use Test::More tests => 24;
+use Test::More tests => 40;
 use lib '../lib';
 use DateTime;
 use DateTime::Format::Strptime;
@@ -22,6 +22,32 @@ is(to_SdbArrayRefOfInt(\@aofis)->[1], $aofi[1], 'array of str converts to array 
 ok(ref to_SdbArrayRefOfInt(1) eq 'ARRAY', 'coerce int to array');
 is(to_SdbInt(['int000000999999996']), -4, 'coerce array of str to int');
 is(to_SdbInt([5]), 5, 'coerce array of int to int');
+
+# decimal 
+is(to_SdbDecimalAsStr(-4), 'dec000000999999996', 'coersion from decimal to string');
+ok(is_SdbDecimal(-4), 'can identify decimal');
+is(to_SdbDecimal('dec000000999999996'), -4, 'coersion from string to decimal');
+my @aofi = (1,-2,3);
+my @aofis = ('dec000001000000001','dec000000999999998','dec000001000000003');
+is(to_SdbArrayRefOfDecimalAsStr(\@aofi)->[1], $aofis[1], 'array of decimal converts to array of str');
+is(to_SdbArrayRefOfDecimal(\@aofis)->[1], $aofi[1], 'array of str converts to array of decimal');
+ok(ref to_SdbArrayRefOfDecimal(1) eq 'ARRAY', 'coerce decimal to array');
+is(to_SdbDecimal(['dec000000999999996']), -4, 'coerce decimal of str to decimal');
+is(to_SdbDecimal([5]), 5, 'coerce array of decimal to decimal');
+
+
+# decimal 
+is(to_SdbDecimalAsStr(-4.25), 'dec000000999999996.25', 'coersion from decimal to string');
+ok(is_SdbDecimal(-4.25), 'can identify decimal');
+is(to_SdbDecimal('dec000000999999996.25'), -4.25, 'coersion from string to decimal');
+my @aofi = (1.25,-2.36,3.47);
+my @aofis = ('dec000001000000001.25','dec000000999999998.36','dec000001000000003.47');
+is(to_SdbArrayRefOfDecimalAsStr(\@aofi)->[1], $aofis[1], 'array of decimal converts to array of str');
+is(to_SdbArrayRefOfDecimal(\@aofis)->[1], $aofi[1], 'array of str converts to array of decimal');
+ok(ref to_SdbArrayRefOfDecimal(1) eq 'ARRAY', 'coerce decimal to array');
+is(to_SdbDecimal(['dec000000999999996.25']), -4.25, 'coerce decimal of str to decimal');
+is(to_SdbDecimal([5.25]), 5.25, 'coerce array of decimal to decimal');
+
 
 # date
 my $dt = DateTime->now;

--- a/t/04.Types.t
+++ b/t/04.Types.t
@@ -1,4 +1,4 @@
-use Test::More tests => 40;
+use Test::More tests => 48;
 use lib '../lib';
 use DateTime;
 use DateTime::Format::Strptime;
@@ -23,7 +23,7 @@ ok(ref to_SdbArrayRefOfInt(1) eq 'ARRAY', 'coerce int to array');
 is(to_SdbInt(['int000000999999996']), -4, 'coerce array of str to int');
 is(to_SdbInt([5]), 5, 'coerce array of int to int');
 
-# decimal 
+# decimal - whole number 
 is(to_SdbDecimalAsStr(-4), 'dec000000999999996', 'coersion from decimal to string');
 ok(is_SdbDecimal(-4), 'can identify decimal');
 is(to_SdbDecimal('dec000000999999996'), -4, 'coersion from string to decimal');
@@ -47,6 +47,19 @@ is(to_SdbArrayRefOfDecimal(\@aofis)->[1], $aofi[1], 'array of str converts to ar
 ok(ref to_SdbArrayRefOfDecimal(1) eq 'ARRAY', 'coerce decimal to array');
 is(to_SdbDecimal(['dec000000999999995.75']), -4.25, 'coerce decimal of str to decimal');
 is(to_SdbDecimal([5.25]), 5.25, 'coerce array of decimal to decimal');
+
+# decimal
+is(to_SdbDecimalAsStr(-76.486881), 'dec000000999999923.513119', 'coersion from decimal to string');
+ok(is_SdbDecimal(-76.486881), 'can identify decimal');
+is(to_SdbDecimal('dec000000999999923.513119'), -76.486881, 'coersion from string to decimal');
+my @aofi = (38.97761,-76.486881);
+my @aofis = ('dec000001000000038.97761','dec000000999999923.513119');
+is(to_SdbArrayRefOfDecimalAsStr(\@aofi)->[1], $aofis[1], 'array of decimal converts to array of str');
+is(to_SdbArrayRefOfDecimal(\@aofis)->[1], $aofi[1], 'array of str converts to array of decimal');
+ok(ref to_SdbArrayRefOfDecimal(1) eq 'ARRAY', 'coerce decimal to array');
+is(to_SdbDecimal(['dec000000999999923.513119']), -76.486881, 'coerce decimal of str to decimal');
+is(to_SdbDecimal([38.97761]), 38.97761, 'coerce array of decimal to decimal');
+
 
 
 # date


### PR DESCRIPTION
## domain_prefix fix

domain_prefix had a default of undef.  This actually causes has_domain_prefix to always return true.

From Moose docs:

> A predicate method tells you whether or not a given attribute is currently set. Note that an attribute can be explicitly set to undef or some other false value, but the predicate will return true.

This was causing the following warning when creating a domain and using items:

> Use of uninitialized value in concatenation (.) or string at /home/kmcgrath/SimpleDB-Class/lib/SimpleDB/Class.pm line 303.
## Decimal Type Addition

The new type allows for a number with precision after the decimal point to be used in comparisons and ordering.  Good for storing prices, geo coordinates, etc...

The implementation basically keeps the same %015d format Int uses for the characters to the left of the decimal point and allows any number of characters to the right of the decimal point.

Added POD and tests.
## Thanks!

Thanks for putting together this project together, having a lot of fun at the moment messing around with SimpleDB and Perl.
